### PR TITLE
Add new optional parameter to the filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Template::Plugin::Filter::Base64 - encoding b64 filter for Template Toolkit
 
     Optional. Value means default charset (e.g. 'cp1251'). Result - convert text with html entities before base64-encoding
 
+- dont\_broken\_into\_lines\_each\_76\_char
+
+    Optional. If true, the returned encoded string will not be broken into lines when there are more than 76 characters.
+
 # SEE ALSO
 
 MIME::Base64 - Encoding and decoding of base64 strings [http://search.cpan.org/~gaas/MIME-Base64/Base64.pm](http://search.cpan.org/~gaas/MIME-Base64/Base64.pm)

--- a/lib/Template/Plugin/Filter/Base64.pm
+++ b/lib/Template/Plugin/Filter/Base64.pm
@@ -10,7 +10,7 @@ use Encode;
 use MIME::Base64 qw(encode_base64);
 use HTML::Entities qw(encode_entities_numeric);
 
-our $VERSION = "0.02";
+our $VERSION = "0.03";
 
 sub init {
     my ($self) = @_;
@@ -34,9 +34,14 @@ sub filter {
             $text = encode_entities_numeric($text);
         }
     }
-
-    my $encoded = encode_base64($text);
-
+    
+    my $encoded;
+    if ($self->{ _CONFIG } && (ref($self->{ _CONFIG }) eq 'HASH') && $self->{ _CONFIG }->{dont_broken_into_lines_each_76_char}) {
+        $encoded = encode_base64($text, '');
+    } else {
+        $encoded = encode_base64($text);
+    }
+    
     return $encoded
 }
 
@@ -52,7 +57,7 @@ Template::Plugin::Filter::Base64 - encoding b64 filter for Template Toolkit
 
 =head1 SYNOPSIS
 
-    [% USE Filter.Base64 trim => 1, use_html_entity => 'cp1251' %]
+    [% USE Filter.Base64 trim => 1, use_html_entity => 'cp1251', dont_broken_into_lines_each_76_char => 1 %]
     [% FILTER b64 %]
         Hello, world!
     [% END %]
@@ -72,6 +77,14 @@ Optional. If true, removes trailing blank characters (and lf, cr) of an input st
 =item use_html_entity (string)
 
 Optional. Value means default charset (e.g. 'cp1251'). Result - convert text with html entities before base64-encoding
+
+=back
+
+=over
+
+=item dont_broken_into_lines_each_76_char
+
+Optional. If true, call the function MIME::Base64::encode_base64( $bytes, '' ) whith empty string for the parameter $eol. The returned encoded string is broken into lines of no more than 76 characters each and it will end with $eol unless it is empty. Pass an empty string as second argument if you do not want the encoded string to be broken into lines
 
 =back
 


### PR DESCRIPTION
dont_broken_into_lines_each_76_char

Causes by the MIME:Base64
 - The returned encoded string is broken into lines of no more than 76
characters each and it will end with $eol unless it is empty. Pass an
empty string as second argument if you do not want the encoded string to
be broken into lines.